### PR TITLE
chore: use netcore dependency of bouncycastle

### DIFF
--- a/BeatTogether.MasterServer.Kernel/BeatTogether.MasterServer.Kernel.csproj
+++ b/BeatTogether.MasterServer.Kernel/BeatTogether.MasterServer.Kernel.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle" Version="1.8.6.1" />
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="NetCoreServer" Version="5.0.0" />

--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,4 @@ run: require-dotnet ## Run locally
 	cp -n BeatTogether.MasterServer/cert.pem BeatTogether.MasterServer/key.pem run/ || true
 
 	cd run && ../local_setup.sh
-	cd run && dotnet run -p ../BeatTogether.MasterServer -c Debug $(ARGS)
+	cd run && dotnet watch -p ../BeatTogether.MasterServer run -c Debug $(ARGS)


### PR DESCRIPTION
this fixes:
 warning NU1701: Package 'BouncyCastle 1.8.6.1' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework 'net5.0'. This package may not be fully compatible with your project.

also, changed to use watch in make run.