### PR TITLE
fix: direct connections, send correct endpoint

### DIFF
--- a/BeatTogether.MasterServer.Kernel/Implementations/UserService.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/UserService.cs
@@ -309,7 +309,8 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
                 };
             }
 
-            var remoteEndPoint = (IPEndPoint)session.EndPoint;
+            var connectingEndPoint = (IPEndPoint)session.EndPoint;
+            var remoteEndPoint = (IPEndPoint)hostSession.EndPoint;
             if (request.UseRelay)
             {
                 GetAvailableRelayServerResponse getAvailableRelayServerResponse;
@@ -363,6 +364,7 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
                     };
                 }
                 remoteEndPoint = IPEndPoint.Parse(getAvailableRelayServerResponse.RemoteEndPoint);
+                connectingEndPoint = remoteEndPoint;
             }
 
             // Let the host know that someone is about to connect (hole-punch)
@@ -370,7 +372,7 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
             {
                 UserId = request.UserId,
                 UserName = request.UserName,
-                RemoteEndPoint = remoteEndPoint,
+                RemoteEndPoint = connectingEndPoint,
                 Random = request.Random,
                 PublicKey = request.PublicKey,
                 IsConnectionOwner = false,


### PR DESCRIPTION
### Summary
This fixes direct connections by sending the host's endpoint, rather than the client's endpoint on the initial (non-relay) connection attempt.

### Background
I was testing direct connections through BeatTogether, and I noticed that the client was actually trying to connect to itself, before attempting a relay connection.

It looks like this may have been an oversight where the the client's endpoint was being sent in the `ConnectToServerResponse`, instead of the host's endpoint.

I believe this PR changes the behavior so both flows are correct:
- Non-relay connection: client gets the host endpoint, host gets the client endpoint for hole-punch
- Relay connections: client and host both get the relay endpoint