### PR TITLE
UserService: Support connecting by secret

### DIFF
--- a/BeatTogether.MasterServer.Kernel/Implementations/UserService.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/UserService.cs
@@ -275,7 +275,12 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
                 $"UseRelay={request.UseRelay})."
             );
 
-            var server = await _serverRepository.GetServerByCode(request.Code);
+            Server server = null;
+            if (!String.IsNullOrEmpty(request.Code))
+                server = await _serverRepository.GetServerByCode(request.Code);
+            else if (!String.IsNullOrEmpty(request.Secret))
+                server = await _serverRepository.GetServer(request.Secret);
+            
             if (server is null)
                 return new ConnectToServerResponse
                 {


### PR DESCRIPTION
We've observed some connections (particularly LAN connections) failing on the 2nd/relay connection attempt.

Further investigation reveals that the second connection attempt only contains a secret and no code, causing an `InvalidCode` response to be issued. This PR simply adds support for looking up servers by their secret if the code is missing.