### PR TITLE
feat: version specific messages / protocol v3

### DIFF
--- a/BeatTogether.MasterServer.Kernel/Implementations/UserService.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/UserService.cs
@@ -418,7 +418,8 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
                 IsDedicatedServer = false,
                 RemoteEndPoint = remoteEndPoint,
                 Random = server.Random,
-                PublicKey = server.PublicKey
+                PublicKey = server.PublicKey,
+                Code = server.Code
             };
         }
 


### PR DESCRIPTION
This PR adds support for master server protocol v3 messages.

This fixes an issue where joining clients cannot see the lobby code:
https://github.com/pythonology/BeatTogether/issues/19

This PR depends on changes to BeatTogether.Core:
https://github.com/pythonology/BeatTogether.Core/pull/2