### PR TITLE
Changing SessionTimeToLive

### DIFF
--- a/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
+++ b/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
@@ -3,6 +3,6 @@
     public class MasterServerConfiguration
     {
         public string EndPoint { get; set; } = "127.0.0.1:2328";
-        public int SessionTimeToLive { get; set; } = 180;
+        public int SessionTimeToLive { get; set; } = 30;
     }
 }


### PR DESCRIPTION
I propose changing this to 30 seconds instead of 2 minutes, as waiting for 2 minutes to re-join a server instance after crashing feels quite slow.