### PR TITLE
Merging joining fixes

### DIFF
--- a/BeatTogether.MasterServer.Data/Abstractions/Repositories/IServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Abstractions/Repositories/IServerRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 using BeatTogether.MasterServer.Domain.Enums;
 using BeatTogether.MasterServer.Domain.Models;
 
@@ -27,6 +28,7 @@ namespace BeatTogether.MasterServer.Data.Abstractions.Repositories
 
         Task<bool> AddServer(Server server);
         Task<bool> RemoveServer(string secret);
+        Task<bool> RemoveServersWithEndpoint(IPAddress EndPoint);
 
         Task<bool> IncrementCurrentPlayerCount(string secret);
         Task<bool> DecrementCurrentPlayerCount(string secret);

--- a/BeatTogether.MasterServer.Data/Abstractions/Repositories/IServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Abstractions/Repositories/IServerRepository.cs
@@ -31,6 +31,5 @@ namespace BeatTogether.MasterServer.Data.Abstractions.Repositories
         Task<bool> IncrementCurrentPlayerCount(string secret);
         Task<bool> DecrementCurrentPlayerCount(string secret);
         void UpdateCurrentPlayerCount(string secret, int currentPlayerCount);
-        void SetLastPlayerTime(string Secret);
     }
 }

--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/MemoryServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/MemoryServerRepository.cs
@@ -137,12 +137,6 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
                 return;
             server.CurrentPlayerCount = currentPlayerCount;
         }
-        public void SetLastPlayerTime(string Secret)
-        {
-            if (!_servers.TryGetValue(Secret, out var server))
-                return;
-            server.LastPlayerJoinTime = System.DateTime.Now;
-        }
 
     }
 }

--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/MemoryServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/MemoryServerRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using BeatTogether.MasterServer.Data.Abstractions.Repositories;
 using BeatTogether.MasterServer.Domain.Enums;
@@ -114,12 +115,29 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
             _serversByCode.TryRemove(server.Code, out _);
             return Task.FromResult(true);
         }
+        public Task<bool> RemoveServersWithEndpoint(IPAddress EndPoint)
+        {
+            List<string> secrets = new();
+            foreach (var server in _servers)
+            {
+                if(server.Value.RemoteEndPoint.Address.ToString() == EndPoint.ToString())
+                {
+                    secrets.Add(server.Key);
+                }
+            }
+            foreach (string secret in secrets)
+            {
+                RemoveServer(secret);
+            }
+            return Task.FromResult(true);
+        }
 
         public Task<bool> IncrementCurrentPlayerCount(string secret)
         {
             if (!_servers.TryGetValue(secret, out var server))
                 return Task.FromResult(false);
             server.CurrentPlayerCount++;
+            _serversByCode[server.Code].CurrentPlayerCount++;
             return Task.FromResult(true);
         }
 
@@ -128,6 +146,7 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
             if (!_servers.TryGetValue(secret, out var server))
                 return Task.FromResult(false);
             server.CurrentPlayerCount--;
+            _serversByCode[server.Code].CurrentPlayerCount--;
             return Task.FromResult(true);
         }
 
@@ -136,6 +155,7 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
             if (!_servers.TryGetValue(secret, out var server))
                 return;
             server.CurrentPlayerCount = currentPlayerCount;
+            _serversByCode[server.Code].CurrentPlayerCount = currentPlayerCount;
         }
 
     }

--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/NodeRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/NodeRepository.cs
@@ -63,10 +63,9 @@ namespace BeatTogether.MasterServer.Data.Abstractions.Repositories
             _nodes[endPoint].Online = true;
         }
         public void SetNodeOffline(IPAddress endPoint)
-        {
+        { 
             if (!_nodes.ContainsKey(endPoint))
-                _nodes.TryAdd(endPoint, new Node(endPoint));
-            _nodes[endPoint].Online = false;
+                _nodes[endPoint].Online = false;
         }
 
         public void ReceivedOK(IPAddress endPoint)
@@ -83,7 +82,7 @@ namespace BeatTogether.MasterServer.Data.Abstractions.Repositories
             bool found = false;
             foreach(var node in GetNodes())
             {
-                if(endPoint.Address == node.Key && node.Value.Online)
+                if(endPoint.Address.ToString() == node.Key.ToString() && node.Value.Online)
                 {
                     found = true; break;
                 }

--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
@@ -139,6 +139,11 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
             return (bool)redisResult;
         }
 
+        public Task<bool> RemoveServersWithEndpoint(IPAddress EndPoint)
+        {
+            return Task.FromResult(false);
+        }
+
         public async Task<bool> IncrementCurrentPlayerCount(string secret)
         {
             var database = _connectionMultiplexer.GetDatabase();

--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
@@ -53,10 +53,6 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
         {
             return Task.FromResult(0);
         }
-        public void SetLastPlayerTime(string Secret)
-        {
-            return;
-        }
 
         public async Task<Server> GetServer(string secret)
         {

--- a/BeatTogether.MasterServer.Domain/Models/Node.cs
+++ b/BeatTogether.MasterServer.Domain/Models/Node.cs
@@ -6,11 +6,13 @@ namespace BeatTogether.MasterServer.Domain.Models
     {
         public IPAddress endpoint { get; }
         public bool Online { get; set; }
+        public bool RemovedServerInstances { get; set; }
 
         public Node(IPAddress endPoint)
         {
             endpoint = endPoint;
             Online = true;
+            RemovedServerInstances = false;
         }
     }
 }

--- a/BeatTogether.MasterServer.Domain/Models/Server.cs
+++ b/BeatTogether.MasterServer.Domain/Models/Server.cs
@@ -11,7 +11,6 @@ namespace BeatTogether.MasterServer.Domain.Models
         public string Secret { get; set; }
         public string Code { get; set; }
         public bool IsPublic { get; set; }
-        public DateTime LastPlayerJoinTime { get; set; }
         public DiscoveryPolicy DiscoveryPolicy { get; set; }
         public InvitePolicy InvitePolicy { get; set; }
         public BeatmapDifficultyMask BeatmapDifficultyMask { get; set; }

--- a/BeatTogether.MasterServer.Kernel/Abstractions/IMasterServerSessionService.cs
+++ b/BeatTogether.MasterServer.Kernel/Abstractions/IMasterServerSessionService.cs
@@ -12,7 +12,6 @@ namespace BeatTogether.MasterServer.Kernel.Abstractions
         MasterServerSession[] GetMasterServerSessions();
         MasterServerSession GetOrAddSession(EndPoint endPoint);
         void AddSession(EndPoint endPoint, string Secret);
-        void SetSessionJoining(EndPoint sessionEndpoint, bool InQue);
         MasterServerSession GetSession(EndPoint endPoint);
         bool TryGetSession(EndPoint endPoint, [MaybeNullWhen(false)] out MasterServerSession session);
         bool CloseSession(MasterServerSession session);

--- a/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
+++ b/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
@@ -2,7 +2,7 @@
 {
     public class MasterServerConfiguration
     {
-        public string EndPoint { get; set; } = "127.0.0.1:2328";
+        public string EndPoint { get; set; } = "192.168.1.227:2328";
         public int SessionTimeToLive { get; set; } = 240;
     }
 }

--- a/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
+++ b/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
@@ -2,7 +2,7 @@
 {
     public class MasterServerConfiguration
     {
-        public string EndPoint { get; set; } = "192.168.1.227:2328";
+        public string EndPoint { get; set; } = "127.0.0.1:2328";
         public int SessionTimeToLive { get; set; } = 240;
     }
 }

--- a/BeatTogether.MasterServer.Kernel/Implementations/DedicatedServerEventHandler.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/DedicatedServerEventHandler.cs
@@ -72,7 +72,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
         {
             MasterServerSession session = _masterServerSessionService.GetSession((EndPoint)IPEndPoint.Parse(integrationEvent.endPoint));
             _serverRepository.DecrementCurrentPlayerCount(session.Secret);
-            _serverRepository.SetLastPlayerTime(session.Secret);
             _masterServerSessionService.RemoveSecretFromSession(session.EndPoint);
             return Task.CompletedTask;
         }

--- a/BeatTogether.MasterServer.Kernel/Implementations/DedicatedServerEventHandler.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/DedicatedServerEventHandler.cs
@@ -4,7 +4,6 @@ using BeatTogether.MasterServer.Data.Abstractions.Repositories;
 using BeatTogether.MasterServer.Kernel.Abstractions;
 using Microsoft.Extensions.Hosting;
 using Serilog;
-using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,7 +78,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
         private Task NodeStartedHandler(NodeStartedEvent startedEvent)
         {
             _logger.Information(
-                $"Handling {nameof(NodeStartedEvent)} " +
                 $"Node is online: " + startedEvent.endPoint);
             _nodeRepository.SetNodeOnline(IPAddress.Parse(startedEvent.endPoint));
             return Task.CompletedTask;

--- a/BeatTogether.MasterServer.Kernel/Implementations/MasterServerSession.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/MasterServerSession.cs
@@ -24,7 +24,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
         public ECPrivateKeyParameters ServerPrivateKeyParameters { get; set; }
         public byte[] PreMasterSecret { get; set; }
         public DateTimeOffset LastKeepAlive { get; set; }
-        public bool InQue { get; set; }
 
         public MasterServerSession(EndPoint endPoint)
             : base(endPoint)

--- a/BeatTogether.MasterServer.Kernel/Implementations/MasterServerSessionService.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/MasterServerSessionService.cs
@@ -67,12 +67,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
         {
             if (!_sessions.TryRemove(session.EndPoint, out var ServerSession))
                 return false;
-
-            if (ServerSession.Secret != "" && ServerSession.Secret != null)
-            {
-                _autobus.Publish(new DisconnectPlayerFromMatchmakingServerEvent(ServerSession.Secret, ServerSession.UserId));
-            }
-
             if (session.State == MasterServerSessionState.Authenticated)
                 _logger.Information(
                     "Closing session " +
@@ -83,7 +77,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
                 );
             else
                 _logger.Information($"Closing session (EndPoint='{session.EndPoint}').");
-            _serverRepository.DecrementCurrentPlayerCount(ServerSession.Secret);
             session.State = MasterServerSessionState.None;
             return true;
         }
@@ -92,11 +85,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
         {
             if (!_sessions.TryRemove(sessionEndpoint, out var ServerSession))
                 return false;
-
-            if (ServerSession.Secret != "" && ServerSession.Secret != null)
-            {
-                _autobus.Publish(new DisconnectPlayerFromMatchmakingServerEvent(ServerSession.Secret, ServerSession.UserId));
-            }
             if (ServerSession.State == MasterServerSessionState.Authenticated)
                 _logger.Information(
                     "Closing session " +
@@ -107,7 +95,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
                 );
             else
                 _logger.Information($"Closing session (EndPoint='{ServerSession.EndPoint}').");
-            _serverRepository.DecrementCurrentPlayerCount(ServerSession.Secret);
             ServerSession.State = MasterServerSessionState.None;
             return true;
         }
@@ -116,11 +103,6 @@ namespace BeatTogether.MasterServer.Kernel.Implementations
         {
             if (_sessions.ContainsKey(sessionEndpoint))
                 _sessions[sessionEndpoint].Secret = "";
-        }
-        public void SetSessionJoining(EndPoint sessionEndpoint, bool InQue)
-        {
-            if(_sessions.ContainsKey(sessionEndpoint))
-                _sessions[sessionEndpoint].InQue = InQue;
         }
 
         #endregion

--- a/BeatTogether.MasterServer.Kernel/Implementations/MasterServerSessionTickService.cs
+++ b/BeatTogether.MasterServer.Kernel/Implementations/MasterServerSessionTickService.cs
@@ -79,7 +79,8 @@ namespace BeatTogether.MasterServer.Kernel.Implementations.Sessions
 
                 try
                 {
-                    if(!_nodeRepository.WaitingForResponses)
+                    // Remove servers that are hosted on a node if that node is not responsive every 10 seconds
+                    if (!_nodeRepository.WaitingForResponses)
                     {
                         _nodeRepository.StartWaitForAllNodesTask();
                         _nodeRepository.WaitingForResponses = true;


### PR DESCRIPTION
Servers in the master server repository now get removed when a node crashes.
Master server now keeps track of player count and returns the correct Connection Failure Errors.
Master server now keeps track of nodes that are connected and when they are no longer connected.
Master server checks if the game the player is trying to join exists before sending them to it.
Re-Written server joining code to no longer use a mess of nested if statements.
Decreased server joining time to be practically instant if you have a good connection.
Increased time before a player session is discarded, and decreased the tick time between checks to increase performance.
Checks if a joining player already has a session on the server before creating them one.
Removes the player session secret when a player leaves a server.
Adds a players server secret to there session on server join.
Split player joining into multiple functions to increase readability.
General all round stability increase.