### PR TITLE
Support 1.31 / ENet

### DIFF
--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/MemoryServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/MemoryServerRepository.cs
@@ -147,7 +147,8 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
             List<string> secrets = new();
             foreach (var server in _servers)
             {
-                if(server.Value.ServerEndPoint.Address.ToString() == EndPoint.ToString())
+                if(server.Value.LiteNetEndPoint.Address.ToString() == EndPoint.ToString()
+                   || server.Value.ENetEndPoint.Address.ToString() == EndPoint.ToString())
                 {
                     secrets.Add(server.Key);
                 }
@@ -165,7 +166,8 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
 
             foreach (var server in _servers)
             {
-                if (server.Value.ServerEndPoint.Address.ToString() == EndPoint.ToString())
+                if (server.Value.LiteNetEndPoint.Address.ToString() == EndPoint.ToString()
+                    || server.Value.ENetEndPoint.Address.ToString() == EndPoint.ToString())
                 {
                     count++;
                 }
@@ -177,7 +179,8 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
             int count = 0;
             foreach (var server in _servers)
             {
-                if (server.Value.ServerEndPoint.Address.ToString() == EndPoint.ToString())
+                if (server.Value.LiteNetEndPoint.Address.ToString() == EndPoint.ToString()
+                    || server.Value.ENetEndPoint.Address.ToString() == EndPoint.ToString())
                 {
                     count += server.Value.CurrentPlayerCount;
                 }

--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
@@ -119,7 +119,8 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
                     publicServersByPlayerCountKey = RedisKeys.PublicServersByPlayerCount,
                     ServerId = (RedisValue)server.ServerId,
                     ServerName = (RedisValue)server.ServerName,
-                    remoteEndPoint = (RedisValue)server.ServerEndPoint.ToString(),
+                    remoteEndPoint = (RedisValue)server.LiteNetEndPoint.ToString(),
+                    // TODO ENetEndPoint (if that's still a thing by the time we use Redis...)
                     secret = (RedisValue)server.Secret,
                     code = (RedisValue)server.Code,
                     isPublic = (RedisValue)server.IsPublic,

--- a/BeatTogether.MasterServer.Domain/Models/Server.cs
+++ b/BeatTogether.MasterServer.Domain/Models/Server.cs
@@ -8,7 +8,8 @@ namespace BeatTogether.MasterServer.Domain.Models
 
         public string ServerName { get; set; }
         public string ServerId { get; set; }
-        public IPEndPoint ServerEndPoint { get; set; }
+        public IPEndPoint LiteNetEndPoint { get; set; }
+        public IPEndPoint ENetEndPoint { get; set; }
         public string Secret { get; set; }
         public string Code { get; set; }
         public bool IsPublic { get; set; }

--- a/BeatTogether.MasterServer.Kernel/BeatTogether.MasterServer.Kernel.csproj
+++ b/BeatTogether.MasterServer.Kernel/BeatTogether.MasterServer.Kernel.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="BeatTogether.Core.Security" Version="1.2.0" />
-    <PackageReference Include="BeatTogether.DedicatedServer.Interface" Version="1.6.0" />
+    <PackageReference Include="BeatTogether.DedicatedServer.Interface" Version="1.7.0" />
     <PackageReference Include="BeatTogether.Extensions.Autobus.RabbitMQ" Version="1.1.0" />
     <PackageReference Include="BeatTogether.Extensions.Serilog" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.16" />

--- a/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
+++ b/BeatTogether.MasterServer.Kernel/Configuration/MasterServerConfiguration.cs
@@ -4,8 +4,8 @@
     {
         public string EndPoint { get; set; } = "127.0.0.1:2328";
         public int SessionTimeToLive { get; set; } = 180;
-        public string MasterServerVersion { get; } = "1.2.0";
-        public string[] SupportedDediServerVersions { get; } = { "1.3.0" }; //for example, if 1.1 is here, then 1.1.1, 1.1.5, 1.1.23, would all be accepted verisions and 1.2.3 would not
+        public string MasterServerVersion { get; } = "1.3.0";
+        public string[] SupportedDediServerVersions { get; } = { "1.4.0" }; //for example, if 1.1 is here, then 1.1.1, 1.1.5, 1.1.23, would all be accepted verisions and 1.2.3 would not
         public bool AuthenticateClients { get; set; } = true;
     }
 }

--- a/BeatTogether.MasterServer.Kernel/HttpControllers/MasterServerController.cs
+++ b/BeatTogether.MasterServer.Kernel/HttpControllers/MasterServerController.cs
@@ -101,7 +101,7 @@ namespace BeatTogether.MasterServer.Kernel.HttpControllers
                 InvitePolicy = (Messaging.Enums.InvitePolicy)server.GameplayServerConfiguration.InvitePolicy,
                 SongSelectionMode = (Messaging.Enums.SongSelectionMode)server.GameplayServerConfiguration.SongSelectionMode
             };
-            GetServerResponse serverResponse = new(server.ServerEndPoint.Address, server.ServerName, server.ServerId, server.Secret, server.Code, server.IsPublic, server.IsInGameplay, mask, config, server.CurrentPlayerCount);
+            GetServerResponse serverResponse = new(server.LiteNetEndPoint.Address, server.ServerName, server.ServerId,server.Secret, server.Code, server.IsPublic, server.IsInGameplay, mask, config, server.CurrentPlayerCount);
             return new JsonResult(serverResponse);
         }
 
@@ -132,7 +132,7 @@ namespace BeatTogether.MasterServer.Kernel.HttpControllers
                 InvitePolicy = (Messaging.Enums.InvitePolicy)server.GameplayServerConfiguration.InvitePolicy,
                 SongSelectionMode = (Messaging.Enums.SongSelectionMode)server.GameplayServerConfiguration.SongSelectionMode
             };
-            GetServerResponse serverResponse = new(server.ServerEndPoint.Address, server.ServerName, server.ServerId, server.Secret, server.Code, server.IsPublic, server.IsInGameplay, mask, config, server.CurrentPlayerCount);
+            GetServerResponse serverResponse = new(server.LiteNetEndPoint.Address, server.ServerName, server.ServerId, server.Secret, server.Code, server.IsPublic, server.IsInGameplay, mask, config, server.CurrentPlayerCount);
             return new JsonResult(serverResponse);
         }
 

--- a/BeatTogether.MasterServer.Messaging/Messages/User/ConnectToServerResponse.cs
+++ b/BeatTogether.MasterServer.Messaging/Messages/User/ConnectToServerResponse.cs
@@ -39,6 +39,12 @@ namespace BeatTogether.MasterServer.Messaging.Messages.User
         public string ManagerId { get; set; }
 
         public bool Success => Result == ConnectToServerResult.Success;
+        
+        /// <summary>
+        /// Temporary alt endpoint for users connecting on 1.31+ via Ignorance/ENet.
+        /// Not part of the master server response, only used internally.
+        /// </summary>
+        public IPEndPoint RemoteEndPointENet { get; set; } = null;
 
         public void WriteTo(ref SpanBufferWriter bufferWriter)
         {


### PR DESCRIPTION
Adds support for v1.31+ clients:

- Support for dual endpoints per instance (one LiteNet, one ENet)
- Matchmaking auto selects endpoint based on game version (v1.31+ gets sent to ENet endpoint)
- Bump master server to v1.3; supported node version to v1.4

Related dedicated server PR: https://github.com/BeatTogether/BeatTogether.DedicatedServer/pull/135

Note: These changes are mostly temporary, once we can fully drop LiteNet support this is due for a good clean up.