### PR TITLE
Add version ranged lobbies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,4 +351,4 @@ MigrationBackup/
 
 out/
 run/
-/BeatTogether.MasterServer.Kernel/Properties/launchSettings.json
+/BeatTogether.MasterServer/appsettings.LocalDevelopment.json

--- a/BeatTogether.MasterServer.Api/BeatTogether.MasterServer.Api.csproj
+++ b/BeatTogether.MasterServer.Api/BeatTogether.MasterServer.Api.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
     <PackageReference Include="BeatTogether.Extensions.Serilog" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.29" />
   </ItemGroup>

--- a/BeatTogether.MasterServer.Api/BeatTogether.MasterServer.Api.csproj
+++ b/BeatTogether.MasterServer.Api/BeatTogether.MasterServer.Api.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.1.0" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
     <PackageReference Include="BeatTogether.Extensions.Serilog" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.29" />
   </ItemGroup>

--- a/BeatTogether.MasterServer.Api/Configuration/ApiServerConfiguration.cs
+++ b/BeatTogether.MasterServer.Api/Configuration/ApiServerConfiguration.cs
@@ -1,10 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using BeatTogether.Core.Enums;
+using BeatTogether.Core.Models;
+using BeatTogether.MasterServer.Api.Util;
 
 namespace BeatTogether.MasterServer.Api.Configuration
 {
-    public class ApiServerConfiguration
+    public sealed class ApiServerConfiguration
     {
         public int SessionTimeToLive { get; set; } = 180;
         public bool AuthenticateClients { get; set; } = true;
+        public HashSet<VersionRange> VersionRanges { get; set; } = new();
+        public HashSet<Platform> AuthedClients { get; set; } = new();
     }
 }

--- a/BeatTogether.MasterServer.Api/Extensions/HostBuilderExtensions.cs
+++ b/BeatTogether.MasterServer.Api/Extensions/HostBuilderExtensions.cs
@@ -7,8 +7,10 @@ using BeatTogether.MasterServer.Api.Configuration;
 using BeatTogether.MasterServer.Api.Implementations;
 using BeatTogether.MasterServer.Api.Implimentations;
 using BeatTogether.MasterServer.Kernel.Implementations.Providers;
+using BinaryRecords.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -38,9 +40,14 @@ namespace BeatTogether.Extensions
                         )
                         .Configure(applicationBuilder =>
                             applicationBuilder
-                                .UseRouting()
+	                            .Use((context, next) =>
+	                            {
+		                            context.Response.Headers.Add("X-Robots-Tag", "noindex, nofollow"); // Tell everyone that we don't want to be indexed
+		                            return next(context);
+	                            })
+								.UseRouting()
                                 .UseEndpoints(endPointRouteBuilder => endPointRouteBuilder.MapControllers())
-                        )
-                );
+						)
+				);
     }
 }

--- a/BeatTogether.MasterServer.Api/HttpControllers/GetMultiplayerInstanceController.cs
+++ b/BeatTogether.MasterServer.Api/HttpControllers/GetMultiplayerInstanceController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using BeatTogether.MasterServer.Messaging.Enums;
 using BeatTogether.MasterServer.Messaging.Models;
@@ -10,8 +11,10 @@ using BeatTogether.MasterServer.Api.Implementations;
 using BeatTogether.MasterServer.Api.Abstractions;
 using BeatTogether.MasterServer.Api.Util;
 using System.Text;
+using BeatTogether.Core.Models;
 using BeatTogether.MasterServer.Domain.Models;
 using BeatTogether.MasterServer.Api.Abstractions.Providers;
+using BeatTogether.MasterServer.Api.Configuration;
 
 namespace BeatTogether.MasterServer.Api.HttpControllers
 {
@@ -30,12 +33,15 @@ namespace BeatTogether.MasterServer.Api.HttpControllers
 
         private readonly ILayer2 _layer2;
 
-        public GetMultiplayerInstanceController(
+        private readonly ApiServerConfiguration _apiServerConfiguration;
+
+		public GetMultiplayerInstanceController(
             IMasterServerSessionService sessionService,
             ILayer2 layer2,
             IServerCodeProvider serverCodeProvider,
             ISecretProvider secretProvider,
-            IUserAuthenticator userAuthenticator)
+            IUserAuthenticator userAuthenticator,
+            ApiServerConfiguration configuration)
         {
             _layer2 = layer2;
             _sessionService = sessionService;
@@ -43,8 +49,9 @@ namespace BeatTogether.MasterServer.Api.HttpControllers
             _secretProvider = secretProvider;
             _userAuthenticator = userAuthenticator;
 
-            
-            _logger = Log.ForContext<GetMultiplayerInstanceController>();
+            _apiServerConfiguration = configuration;
+
+			_logger = Log.ForContext<GetMultiplayerInstanceController>();
         }
 
         /// <summary>
@@ -56,8 +63,6 @@ namespace BeatTogether.MasterServer.Api.HttpControllers
         {
             var response = new GetMultiplayerInstanceResponse();
             response.AddRequestContext(request);
-
-            // TODO Validate game client version supported range?
 
             if (HttpContext.Connection.RemoteIpAddress is null)
             {
@@ -143,14 +148,25 @@ namespace BeatTogether.MasterServer.Api.HttpControllers
             {
                 string secret = request.PrivateGameSecret;
                 string managerId = FixedServerUserId;
+                VersionRange supportedRange = VersionRange.FindVersionRange(_apiServerConfiguration.VersionRanges.ToList(), session.PlayerClientVersion!);
+                if (supportedRange == null)
+                {
+					// Version not supported at all according to config
+					_logger.Error($"Could not find matching version range for client version: {session.PlayerClientVersion}");
+					response.ErrorCode = MultiplayerPlacementErrorCode.LobbyHostVersionMismatch;
+                    return new JsonResult(response);
+                }
+
+                _logger.Debug(
+	                $"Found version range MinVersion: '{supportedRange.MinVersion}' MaxVersion: '{supportedRange.MaxVersion}' for client version '{session.PlayerClientVersion}'");
                 if (!isQuickplay)
-                    managerId = session.HashedUserId;//sets the manager to the player who is requesting
+                    managerId = session.HashedUserId; //sets the manager to the player who is requesting
                 else
                     secret = _secretProvider.GetSecret();
 
                 string ServerName = string.Empty;
                 if (isQuickplay)
-                    ServerName = "BeatTogether Quickplay: " + ((Core.Enums.BeatmapDifficultyMask)request.BeatmapLevelSelectionMask.BeatmapDifficultyMask).ToString();
+                    ServerName = "BeatTogether Quickplay: " + ((Core.Enums.BeatmapDifficultyMask)request.BeatmapLevelSelectionMask.BeatmapDifficultyMask);
                 else if (request.ExtraServerConfiguration != null && request.ExtraServerConfiguration.ServerName != null)
                 {
                     ServerName = request.ExtraServerConfiguration.ServerName;
@@ -184,7 +200,8 @@ namespace BeatTogether.MasterServer.Api.HttpControllers
                     ServerStartJoinTimeout = 10000L,
                     //ServerStartJoinTimeout = request.ExtraServerConfiguration.Timeout ?? 10, //Dont allow everyone to do this as -1 means infinite server online time, server wont turn off when a player leaves
                     PermanentManager = request.ExtraServerConfiguration != null ? request.ExtraServerConfiguration.PermenantManger ?? true : true,
-                };
+                    SupportedVersionRange = supportedRange
+				};
                 //Missing values from the server instance such as endpoint, will be added from within the CreateInstance function below.
                 if (!await _layer2.CreateInstance(server))
                 {
@@ -200,6 +217,15 @@ namespace BeatTogether.MasterServer.Api.HttpControllers
             {
                 response.ErrorCode = MultiplayerPlacementErrorCode.ServerAtCapacity;
                 response.PollIntervalMs = -1;
+                return new JsonResult(response);
+            }
+
+            // Checks if the joining players version is witin the supported range of the lobby
+            if (!VersionRange.VersionRangeSatisfies(server.SupportedVersionRange,
+	                session.PlayerClientVersion.ToString()))
+            {
+                _logger.Warning($"Player '{session.HashedUserId}' on version '{session.PlayerClientVersion}' cannot join lobby with range {server.SupportedVersionRange.MinVersion} - {server.SupportedVersionRange.MaxVersion}");
+                response.ErrorCode = MultiplayerPlacementErrorCode.LobbyHostVersionMismatch;
                 return new JsonResult(response);
             }
 

--- a/BeatTogether.MasterServer.Api/Implimentations/UserAuthenticator.cs
+++ b/BeatTogether.MasterServer.Api/Implimentations/UserAuthenticator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -146,14 +147,8 @@ namespace BeatTogether.MasterServer.Api.Implementations
 
         private bool GetPlatformRequiresAuth(Platform platform)
         {
-            return platform switch
-            {
-                Platform.Steam => true,
-                Platform.OculusQuest => true,
-                Platform.Oculus => true,
-                Platform.Pico => true,
-                _ => false,
-            };
-        }
+			_logger.Debug("Authed Platforms: " + string.Join(", ", _apiServerConfiguration.AuthedClients));
+			return _apiServerConfiguration.AuthedClients.Contains(platform);
+		}
     }
 }

--- a/BeatTogether.MasterServer.Data/Abstractions/Repositories/IServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Abstractions/Repositories/IServerRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
 using BeatTogether.Core.Enums;
+using BeatTogether.Core.Models;
 using BeatTogether.MasterServer.Domain.Models;
 
 namespace BeatTogether.MasterServer.Data.Abstractions.Repositories
@@ -10,14 +11,15 @@ namespace BeatTogether.MasterServer.Data.Abstractions.Repositories
         Task<Server> GetServer(string secret);
         Task<Server> GetServerByCode(string code);
         Task<Server> GetAvailablePublicServer(
-            InvitePolicy invitePolicy,
-            GameplayServerMode serverMode,
-            SongSelectionMode songMode,
-            GameplayServerControlSettings serverControlSettings,
-            BeatmapDifficultyMask difficultyMask,
-            GameplayModifiersMask modifiersMask,
-            string SongPackMasks);
-        Task<bool> UpdateServer(string secret, Server server);
+	        InvitePolicy invitePolicy,
+	        GameplayServerMode serverMode,
+	        SongSelectionMode songMode,
+	        GameplayServerControlSettings serverControlSettings,
+	        BeatmapDifficultyMask difficultyMask,
+	        GameplayModifiersMask modifiersMask,
+	        string SongPackMasks,
+	        VersionRange versionRange);
+		Task<bool> UpdateServer(string secret, Server server);
         Task<string[]> GetPublicServerSecrets();
         Task<string[]> GetPublicServerCodes();
         Task<Server[]> GetPublicServerList();

--- a/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
+++ b/BeatTogether.MasterServer.Data/Implementations/Repositories/ServerRepository.cs
@@ -97,7 +97,8 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
             GameplayServerControlSettings serverControlSettings,
             BeatmapDifficultyMask difficultyMask,
             GameplayModifiersMask modifiersMask,
-            string SongPackMasks)
+            string SongPackMasks,
+            VersionRange versionRange)
         {
             var database = _connectionMultiplexer.GetDatabase();
             var redisValues = await database.SortedSetRangeByScoreAsync(RedisKeys.PublicServersByPlayerCount, take: 1);
@@ -132,6 +133,7 @@ namespace BeatTogether.MasterServer.Data.Implementations.Repositories
                     currentPlayerCount = (RedisValue)server.CurrentPlayerCount,
                     //random = (RedisValue)server.Random,
                     //publicKey = (RedisValue)server.PublicKey
+                    //SupportedVersionRange = (RedisValue)()
                 },
                 flags: CommandFlags.DemandMaster
             );

--- a/BeatTogether.MasterServer.Domain/BeatTogether.MasterServer.Domain.csproj
+++ b/BeatTogether.MasterServer.Domain/BeatTogether.MasterServer.Domain.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/BeatTogether.MasterServer.Domain/BeatTogether.MasterServer.Domain.csproj
+++ b/BeatTogether.MasterServer.Domain/BeatTogether.MasterServer.Domain.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.0.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
   </ItemGroup>
 
 </Project>

--- a/BeatTogether.MasterServer.Domain/Models/Server.cs
+++ b/BeatTogether.MasterServer.Domain/Models/Server.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using BeatTogether.Core.Abstractions;
 using BeatTogether.Core.Enums;
@@ -23,6 +24,8 @@ namespace BeatTogether.MasterServer.Domain.Models
         public HashSet<string> PlayerHashes { get; set; } = new();
 
         public string ManagerId { get; set; }
+
+        public VersionRange SupportedVersionRange { get; set; }
         public bool PermanentManager { get; set; }
         public long ServerStartJoinTimeout { get; set; }
         public bool NeverCloseServer { get; set; }

--- a/BeatTogether.MasterServer.Interface/BeatTogether.MasterServer.Interface.csproj
+++ b/BeatTogether.MasterServer.Interface/BeatTogether.MasterServer.Interface.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autobus.Abstractions" Version="0.1.5" />
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/BeatTogether.MasterServer.Interface/BeatTogether.MasterServer.Interface.csproj
+++ b/BeatTogether.MasterServer.Interface/BeatTogether.MasterServer.Interface.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autobus.Abstractions" Version="0.1.5" />
-    <PackageReference Include="BeatTogether.Core" Version="1.0.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
   </ItemGroup>
 
 </Project>

--- a/BeatTogether.MasterServer.Messaging/BeatTogether.MasterServer.Messaging.csproj
+++ b/BeatTogether.MasterServer.Messaging/BeatTogether.MasterServer.Messaging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/BeatTogether.MasterServer.Messaging/BeatTogether.MasterServer.Messaging.csproj
+++ b/BeatTogether.MasterServer.Messaging/BeatTogether.MasterServer.Messaging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.1.0" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/BeatTogether.MasterServer.Messaging/Enums/MultiplayerPlacementErrorCode.cs
+++ b/BeatTogether.MasterServer.Messaging/Enums/MultiplayerPlacementErrorCode.cs
@@ -10,6 +10,9 @@
         AuthenticationFailed,
         RequestTimeout,
         MatchmakingTimeout,
-        LobbyHostVersionMismatch = 50
+        // Below are our custom error codes
+        GameVersionUnknown = 50,
+        GameVersionTooOld,
+		GameVersionTooNew
     }
 }

--- a/BeatTogether.MasterServer.Messaging/Enums/MultiplayerPlacementErrorCode.cs
+++ b/BeatTogether.MasterServer.Messaging/Enums/MultiplayerPlacementErrorCode.cs
@@ -9,6 +9,7 @@
         ServerAtCapacity,
         AuthenticationFailed,
         RequestTimeout,
-        MatchmakingTimeout
+        MatchmakingTimeout,
+        LobbyHostVersionMismatch = 50
     }
 }

--- a/BeatTogether.MasterServer.NodeController/BeatTogether.MasterServer.NodeController.csproj
+++ b/BeatTogether.MasterServer.NodeController/BeatTogether.MasterServer.NodeController.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="BeatTogether.Core" Version="1.1.0" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
     <PackageReference Include="BeatTogether.DedicatedServer.Interface" Version="2.0.2" />
     <PackageReference Include="BeatTogether.Extensions.Autobus.RabbitMQ" Version="1.1.0" />
     <PackageReference Include="BeatTogether.Extensions.Serilog" Version="2.1.0" />

--- a/BeatTogether.MasterServer.NodeController/BeatTogether.MasterServer.NodeController.csproj
+++ b/BeatTogether.MasterServer.NodeController/BeatTogether.MasterServer.NodeController.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
     <PackageReference Include="BeatTogether.DedicatedServer.Interface" Version="2.0.2" />
     <PackageReference Include="BeatTogether.Extensions.Autobus.RabbitMQ" Version="1.1.0" />
     <PackageReference Include="BeatTogether.Extensions.Serilog" Version="2.1.0" />

--- a/BeatTogether.MasterServer.NodeController/Configuration/NodeControllerConfiguration.cs
+++ b/BeatTogether.MasterServer.NodeController/Configuration/NodeControllerConfiguration.cs
@@ -3,8 +3,8 @@ namespace BeatTogether.MasterServer.NodeController.Configuration
 {
     public class NodeControllerConfiguration
     {
-        public Version MasterServerVersion { get; } = new(2,0,0);
-        public Version[] SupportedDediServerVersions { get; } = { new(2,0,0) }; //for example, if 1.1 is here, then 1.1.1, 1.1.5, 1.1.23, would all be accepted verisions and 1.2.3 would not. Only change when dedi and master would be incompat otherwise
+        public Version MasterServerVersion { get; } = new(2,1,0);
+        public Version[] SupportedDediServerVersions { get; } = { new(2,1,0) }; //for example, if 1.1 is here, then 1.1.1, 1.1.5, 1.1.23, would all be accepted verisions and 1.2.3 would not. Only change when dedi and master would be incompat otherwise
         public long TicksBetweenUpdatingCachedApiResponses { get; set; } = TimeSpan.TicksPerSecond;
     }
 }

--- a/BeatTogether.MasterServer.NodeController/HttpControllers/MasterServerController.cs
+++ b/BeatTogether.MasterServer.NodeController/HttpControllers/MasterServerController.cs
@@ -26,6 +26,17 @@ namespace BeatTogether.MasterServer.NodeController.HttpControllers
         }
 
         /// <summary>
+        /// Returns a test message so players can test if the connection works
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("test")]
+        public string GetTestMessage()
+        {
+	        return "Yay, seems like you are able to connect to the master server!";
+        }
+
+        /// <summary>
         /// Returns the amount of active instances
         /// </summary>
         [HttpGet]

--- a/BeatTogether.MasterServer.NodeController/NodeControllerLayer.cs
+++ b/BeatTogether.MasterServer.NodeController/NodeControllerLayer.cs
@@ -10,6 +10,7 @@ using BeatTogether.MasterServer.NodeController.Abstractions;
 using BinaryRecords;
 using Serilog;
 using System.Net;
+using BeatTogether.Core.Models;
 
 namespace BeatTogether.MasterServer.NodeController
 {
@@ -61,11 +62,12 @@ namespace BeatTogether.MasterServer.NodeController
             return Task.CompletedTask;
         }
 
-        public async Task<IServerInstance?> GetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks)
+        public async Task<IServerInstance?> GetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks, VersionRange versionRange)
         {
-            return await _serverRepository.GetAvailablePublicServer(invitePolicy, serverMode, songMode, serverControlSettings, difficultyMask, modifiersMask, songPackMasks);
+	        return await _serverRepository.GetAvailablePublicServer(invitePolicy, serverMode, songMode, serverControlSettings, difficultyMask, modifiersMask, songPackMasks, versionRange);
         }
-        public async Task<IServerInstance?> GetServer(string secret)
+
+		public async Task<IServerInstance?> GetServer(string secret)
         {
             return await _serverRepository.GetServer(secret);
         }

--- a/BeatTogether.MasterServer/BeatTogether.MasterServer.csproj
+++ b/BeatTogether.MasterServer/BeatTogether.MasterServer.csproj
@@ -12,11 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="appsettings.LocalDevelopment.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="appsettings.Development.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 

--- a/BeatTogether.MasterServer/BeatTogether.MasterServer.csproj
+++ b/BeatTogether.MasterServer/BeatTogether.MasterServer.csproj
@@ -7,15 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="appsettings.Development.json" />
+    <None Remove="appsettings.*.json" />
     <None Remove="appsettings.json" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="appsettings.LocalDevelopment.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="appsettings.Development.json">
+    <Content Include="appsettings.*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.json">

--- a/BeatTogether.MasterServer/Properties/launchSettings.json
+++ b/BeatTogether.MasterServer/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "BeatTogether.MasterServer": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "LocalDevelopment"
+      }
+    }
+  }
+}

--- a/BeatTogether.MasterServer/appsettings.Development.json
+++ b/BeatTogether.MasterServer/appsettings.Development.json
@@ -1,14 +1,31 @@
 ﻿{
   "Urls": "http://0.0.0.0:8989",
+  "RabbitMQ": {
+    "HostName": "127.0.0.1"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Verbose",
       "Overrides": {
         "Microsoft": "Warning"
       }
-    },
-    "ServerConfiguration": {
-      "AuthenticateClients": false
     }
+  },
+  "ServerConfiguration": {
+    "VersionRanges": [
+      {
+        "MinVersion": "1.37.0",
+        "MaxVersion": "1.39.1"
+      },
+      {
+        "MinVersion": "1.40.0"
+      }
+    ],
+    "AuthenticateClients": true,
+    "AuthedClients": [
+      "Steam",
+      "Oculus",
+      "Pico"
+    ]
   }
 }

--- a/BeatTogether.MasterServer/appsettings.json
+++ b/BeatTogether.MasterServer/appsettings.json
@@ -1,5 +1,8 @@
 ﻿{
   "Urls": "http://0.0.0.0:8989",
+  "RabbitMQ": {
+    "HostName": "127.0.0.1"
+  },
   "Serilog": {
     "File": {
       "Path": "logs/BeatTogether.MasterServer-{Date}.log"
@@ -9,9 +12,24 @@
       "Overrides": {
         "Microsoft": "Warning"
       }
-    },
-    "ServerConfiguration": {
-      "AuthenticateClients": false
     }
+  },
+  "ServerConfiguration": {
+    "VersionRanges": [
+      {
+        "MinVersion": "1.37.0",
+        "MaxVersion": "1.39.1"
+      },
+      {
+        "MinVersion": "1.40.0"
+      }
+    ],
+    "AuthenticateClients": true,
+    "AuthedClients": [
+      "Steam",
+      "Oculus",
+      "Pico",
+      "OculusQuest"
+    ]
   }
 }


### PR DESCRIPTION
This pull request adds version ranges to lobbies, the version ranges are set in the master server config.
This also adds a /test endpoint to the master api
Also adds a X-Robots-Tag: noindex, nofollow header to responses for master server requests